### PR TITLE
Add contacts

### DIFF
--- a/content/contacts.md
+++ b/content/contacts.md
@@ -1,0 +1,23 @@
++++
+title = 'Contacts'
+menu = 'main'
+weight = 100
++++
+# Contact/How to Join Us
+
+## Slack channel
+
+Join our slack channel [#applied-research-competitions](https://datasciencegt.slack.com/?redir=%2Farchives%2FC05MW3LPZFZ%3Fname%3DC05MW3LPZFZ) on the **DS@GT Slack** to find out more details and chat with us
+
+## Points of Contact
+
+For specific inquiries on our club please reach out to.
+
+*   **Murilo Gustineli**: murilogustineli@gatech.edu
+*   **Ritesh Mehta**: rmehta307@gatech.edu
+*   **Jason Tam**: jtam30@gatech.edu
+
+## Fall 2025 interest form
+
+For Fall 2025 recruitment initiatives, please fill out the following form: [Link](https://docs.google.com/forms/d/e/1FAIpQLSfODo9AxoE0exzTFT2115nYWbYw4dWfDK3jvnDvKoKH-3LkbA/viewform)
+


### PR DESCRIPTION
So when people land on our website they can join slack or reach out per email, if it is not within a recruitment phase with an active form.