### PR TITLE
Fix broken image resolution on mobile

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -61,6 +61,9 @@ figure.captioned-image {
     text-align: center;
     margin: 2em auto;
 }
+figure.captioned-image img {
+    height: auto;
+}
 figure.captioned-image figcaption {
     margin-top: 0.5em;
     font-size: 0.9em;

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -6,9 +6,15 @@
 
 {{ $image := resources.Get $src }}
 {{ if $image }}
-    {{ $image := $image.Resize $resize }}
+    {{ $img800 := $image.Resize "800x webp" }}
+    {{ $img600 := $image.Resize "600x webp" }}
+    {{ $img400 := $image.Resize "400x webp" }}
     <figure class="captioned-image">
-        <img src="{{ $image.RelPermalink }}" alt="{{ $alt }}" loading="lazy" decoding="async" width="{{ $image.Width }}" height="{{ $image.Height }}">
+        <img src="{{ $img800.RelPermalink }}"
+             srcset="{{ $img400.RelPermalink }} 400w, {{ $img600.RelPermalink }} 600w, {{ $img800.RelPermalink }} 800w"
+             sizes="(max-width: 600px) 100vw, 800px"
+             alt="{{ $alt }}" loading="lazy" decoding="async"
+             width="{{ $img800.Width }}" height="{{ $img800.Height }}">
         {{ with $alt }}<figcaption><b>Figure: </b>{{ . }}</figcaption>{{ end }}
     </figure>
 {{ else }}


### PR DESCRIPTION
## Summary

- Add `height: auto` CSS rule for captioned images so aspect ratio is preserved when `max-width: 100%` constrains width on narrow viewports
- Generate responsive `srcset` with 400/600/800px WebP variants so mobile devices download appropriately sized images instead of always getting 800px

## Test plan

- [ ] Run `docker compose up --build` and open the site with DevTools mobile emulation (iPhone SE, Pixel 5)
- [ ] Verify images on homepage, history, and join/fall-2025 pages maintain correct aspect ratio at all viewport widths
- [ ] Inspect `<img>` elements to confirm `srcset` contains three width descriptors